### PR TITLE
EE-21420 Fix the Kube Cert Authority setup

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,25 +14,17 @@ if [[ ${ENVIRONMENT} == "pr" ]] ; then
     export KUBE_TOKEN=${PTTG_IP_PR}
     export DNS_PREFIX=
     export KC_REALM=pttg-production
-    export CLUSTER_NAME="acp-prod"
+    export KUBE_CERTIFICATE_AUTHORITY=https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/acp-prod.crt
 else
     export KUBE_TOKEN=${PTTG_IP_DEV}
     export DNS_PREFIX=${ENVIRONMENT}.notprod.
     export KC_REALM=pttg-qa
-    export CLUSTER_NAME="acp-notprod"
+    export KUBE_CERTIFICATE_AUTHORITY=https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/acp-notprod.crt
 fi
 
 export DOMAIN_NAME=ipstats.${DNS_PREFIX}pttg.homeoffice.gov.uk
 
 echo "DOMAIN_NAME is $DOMAIN_NAME"
-
-
-export KUBE_CERTIFICATE_AUTHORITY=/tmp/cert.crt
-if ! curl --silent --fail --retry 5 \
-    https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/$CLUSTER_NAME.crt -o $KUBE_CERTIFICATE_AUTHORITY; then
-  echo "[error] failed to download ca for kube api"
-  exit 1
-fi
 
 cd kd || exit 1
 


### PR DESCRIPTION
Curl does not exist in the container. Looking at other projects, it also would seem that declaring the URL as the KUBE_CERTIFICATE_AUTHORITY environment variable will work.